### PR TITLE
Added missing css file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,13 @@
 {
   "name": "bootstrap3-ie10-viewport-bug-workaround",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/Haixing-Hu/bootstrap3-ie10-viewport-bug-workaround",
   "authors": [
     "Twitter, Inc"
   ],
   "main": [
-    "./ie10-viewport-bug-workaround.js"
+    "./ie10-viewport-bug-workaround.js",
+    "./ie10-viewport-bug-workaround.css"
   ],
   "keywords": [
     "bootstrap",

--- a/ie10-viewport-bug-workaround.css
+++ b/ie10-viewport-bug-workaround.css
@@ -1,0 +1,15 @@
+/*!
+ * IE10 viewport hack for Surface/desktop Windows 8 bug
+ * Copyright 2014-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+/*
+ * See the Getting Started docs for more information:
+ * http://getbootstrap.com/getting-started/#support-ie10-width
+ */
+@-webkit-viewport { width: device-width; }
+@-moz-viewport    { width: device-width; }
+@-ms-viewport     { width: device-width; }
+@-o-viewport      { width: device-width; }
+@viewport         { width: device-width; }


### PR DESCRIPTION
As reported in issue #3, the css file [ie10-viewport-bug-workaround.css](https://github.com/twbs/bootstrap/blob/master/docs/assets/css/ie10-viewport-bug-workaround.css) was missing.
I added it, and included the reference in the bower.json file.
