### PR TITLE
chore: removed bootstrap from bower dependency list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,8 +14,5 @@
     "viewport bug"
   ],
   "license": "MIT",
-  "dependencies": {
-    "bootstrap": ">=3.0.0"
-  },
   "ignore": []
 }


### PR DESCRIPTION
for this case, it's best practise to remove `bootstrap` from dependency list.
